### PR TITLE
Gracefull handling of SIGINT and SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ For Arch Linux users, you can install it in the AUR with the package "clockr"
     help, -h, -help, -H, --h                       Prints this help text.
     about, -a, -about, -A, --a                     Prtins the about text, 
     nodate, -nd, -nodate, -nd, --nd                Doesn't print the date in the clock.
-<<<<<<< HEAD
     -red, -white, blue, -magenta,                  Changes color of clock respectively.
     -green, -yellow, -cyan, -white 
-=======
     twentyfour, -tf, -twentyfour, --tf             Prints the time in 24-hour format
-  
->>>>>>> bb5651d4f82a3c6e170598be1738fd9efc46dee3
 
 # Questions that we think you might have.
 Q: Why isn't X working?

--- a/clockr
+++ b/clockr
@@ -6,6 +6,7 @@ from math import floor
 from datetime import datetime as date
 import sys
 import time
+import signal
 
 for arg in sys.argv:
     twentyfourargs = arg
@@ -79,6 +80,10 @@ def print_date(now):
         addstr(8, len(day_line) + 40, date_line, curses.color_pair(2) | curses.A_BOLD)
 
 
+def gracefull_exit(signal = None, frame = None):
+    curses.endwin()
+    sys.exit()
+
 screen.keypad(1)
 curses.curs_set(0)
 curses.start_color()
@@ -88,6 +93,10 @@ curses.init_pair(2, 3, -1)
 curses.init_pair(3, 0, 3)
 curses.noecho()
 curses.cbreak()
+
+# Register signal handlers for gracefull exit on for instance CTRL-C
+signal.signal(signal.SIGINT, gracefull_exit)
+signal.signal(signal.SIGTERM, gracefull_exit)
 
 a = 0
 while True:
@@ -109,4 +118,4 @@ while True:
     char = screen.getch()
     if char == 113: break
 
-curses.endwin()
+gracefull_exit()


### PR DESCRIPTION
After checking out the original clockr code and starting it up for the first time, I immediately pressed [CTRL] + [C] to quit it This messed with the further terminal session though.

I've added handling for both SIGINT (which is the signal sent by CTRL+C) and SIGTERM (which can be sent by issuing `kill -15 $(pidof /usr/bin/python clockr)`). This now leads the user back to a usable terminal session...