### PR TITLE
Fixed alignment when running in 24-hour mode

### DIFF
--- a/clockr
+++ b/clockr
@@ -109,7 +109,10 @@ def print_time(now):
         for x in range(0, len(time_array[y])):
             char = time_array[y][x]
             color = 1 if char == " " else 3
-            addstr(y, x, " ",
+
+            # If we run in 24-hour mode, the AM/PM will be omitted. This then leads to a misaligned clock, thus
+            # we need to move the clock to the right 2 columns
+            addstr(y, x if not twentyfourhours else x + 2, " ",
                     curses.color_pair(color))
 
     if not twentyfourhours:

--- a/maninfo
+++ b/maninfo
@@ -1,5 +1,6 @@
 [AUTHOR]
-Written by Johnathan "ShaggyTwoDope" Jenkins <twodopeshaggy@gmail.com>, Rolf "pyonium" Don <rolf@pyonium.com>
+Written by Johnathan "ShaggyTwoDope" Jenkins <twodopeshaggy@gmail.com>, Rolf "pyonium" Don <rolf@pyonium.com>,
+Bas Dalenoord <bdalenoord@gmail.com>
 
 [REPORTING BUGS]
 Report bugs to https://github.com/shaggytwodope/clockr/issues


### PR DESCRIPTION
When clockr is running in 24 hour mode, the AM/PM is omitted which leads to a misaligned clock relative to the date... I've made it move over 2 columns when running in 24 hour mode.

Added myself to the maninfo as well, thanks for the quick responses so far!