### PR TITLE
Use KEY_RESIZE and improve display updating precision

### DIFF
--- a/clockr
+++ b/clockr
@@ -124,11 +124,12 @@ def gracefull_exit(signal = None, frame = None):
     sys.exit()
 
 def win_resize():
-    global width, height, origin_x, origin_y
+    global width, height, origin_x, origin_y, last_t
     screen.clear()
     height, width = screen.getmaxyx()
     origin_x = floor(width / 2) - 34
     origin_y = floor(height / 2) - 4
+    last_t = None
 
 screen.keypad(1)
 curses.curs_set(0)
@@ -159,9 +160,11 @@ while True:
         break
 
     now = date.now()
+    if last_t and now.timetuple()[:6] != last_t.timetuple()[:6]:
+      print_time(now)
+      print_date(now)
 
-    print_time(now)
-    print_date(now)
-    time.sleep(1)
+    time.sleep(0.01)
+    last_t = now
 
 gracefull_exit()

--- a/clockr
+++ b/clockr
@@ -42,8 +42,10 @@ color, dateformat, nodate, twentyfourhourarg = get_args()
 
 
 screen          = curses.initscr()
-last_width      = 0
-last_height     = 0
+width = 0
+height = 0
+origin_x = 0
+origin_y = 0
 glyph           = {
     '0': ["  #####   ", " ##   ##  ", "##     ## ", "##     ## ", "##     ## ", " ##   ##  ", "  #####   "],
     '1': ["    ##    ", "  ####    ", "    ##    ", "    ##    ", "    ##    ", "    ##    ", "  ######  "],
@@ -121,6 +123,13 @@ def gracefull_exit(signal = None, frame = None):
     curses.endwin()
     sys.exit()
 
+def win_resize():
+    global width, height, origin_x, origin_y
+    screen.clear()
+    height, width = screen.getmaxyx()
+    origin_x = floor(width / 2) - 34
+    origin_y = floor(height / 2) - 4
+
 screen.keypad(1)
 curses.curs_set(0)
 curses.start_color()
@@ -132,6 +141,7 @@ curses.init_pair(3, 0, 5)
 #
 curses.noecho()
 curses.cbreak()
+screen.timeout(0)
 
 # Register signal handlers for gracefull exit on for instance CTRL-C
 signal.signal(signal.SIGINT, gracefull_exit)
@@ -140,23 +150,18 @@ signal.signal(signal.SIGTERM, gracefull_exit)
 
 a = 0
 getcolor()
+win_resize()
 while True:
-    width = screen.getmaxyx()[1]
-    height = screen.getmaxyx()[0]
-    origin_x = floor(width / 2) - 34
-    origin_y = floor(height / 2) - 4
-    now = date.now()
+    char = screen.getch()
+    if char == curses.KEY_RESIZE:
+        win_resize()
+    elif char in (ord('q'), ord('Q')):
+        break
 
-    if width != last_width or height != last_height: screen.clear()
-    last_width = width
-    last_height = height
+    now = date.now()
 
     print_time(now)
     print_date(now)
     time.sleep(1)
-
-    screen.timeout(30)
-    char = screen.getch()
-    if char == 113: break
 
 gracefull_exit()


### PR DESCRIPTION
1. Normally, I don't like using `global`, but this is the simplest way I can do it without editing a lot.
2. About `time.sleep(1)`

    Which plus `getch()` timeout is 1.03 seconds and also need to add the elapsed time of each iteration, so it's actually 1.03+ seconds. It's a design flaw, and you will see seconds display sometime skipping one second, though it's not actually skipping per se. Anyway, it's a flaw, and I have fixed it in the second commit.

    We don't really need the `getch` timeout, only need the non-blocking, see `timeout(3)`, so I reduced it to 0.

I tried to keep with [PEP8][pep8], but I didn't modify the code near my modifications. It might not be the style it's coded in here, although I don't see absolutely consistent style, so I just used PEP8.

[pep8]: https://www.python.org/dev/peps/pep-0008/